### PR TITLE
Added validation of calendar urls

### DIFF
--- a/.idea/dictionaries/davidmerrick.xml
+++ b/.idea/dictionaries/davidmerrick.xml
@@ -18,6 +18,7 @@
       <w>powells</w>
       <w>serverless</w>
       <w>sparkjava</w>
+      <w>unparseable</w>
       <w>webcal</w>
     </words>
   </dictionary>

--- a/src/main/kotlin/com/merricklabs/aion/exceptions/InvalidCalendarException.kt
+++ b/src/main/kotlin/com/merricklabs/aion/exceptions/InvalidCalendarException.kt
@@ -1,0 +1,8 @@
+package com.merricklabs.aion.exceptions
+
+import org.apache.http.HttpStatus
+import org.apache.http.client.HttpResponseException
+
+class InvalidCalendarException : HttpResponseException {
+    constructor(url: String, message: String) : super(HttpStatus.SC_BAD_REQUEST, "Invalid calendar url: $url. Error: $message")
+}

--- a/src/main/kotlin/com/merricklabs/aion/external/CalendarClient.kt
+++ b/src/main/kotlin/com/merricklabs/aion/external/CalendarClient.kt
@@ -2,11 +2,15 @@ package com.merricklabs.aion.external
 
 import biweekly.Biweekly
 import biweekly.ICalendar
+import com.google.common.net.HttpHeaders.CONTENT_TYPE
+import com.google.common.net.MediaType.I_CALENDAR_UTF_8
+import com.merricklabs.aion.exceptions.InvalidCalendarException
 import mu.KotlinLogging
 import okhttp3.OkHttpClient
 import okhttp3.Request
 import org.koin.core.KoinComponent
 import org.koin.core.inject
+import java.net.URI
 
 private val log = KotlinLogging.logger {}
 
@@ -27,5 +31,24 @@ class CalendarClient : KoinComponent {
         }
 
         throw IllegalArgumentException("Calendar url returned no content.")
+    }
+
+    @Throws(InvalidCalendarException::class)
+    fun validateCalendar(url: String) {
+        try {
+            URI(url)
+        } catch (e: Exception) {
+            throw InvalidCalendarException(url, "Unparseable URL.")
+        }
+
+        val request = Request.Builder()
+                .url(url)
+                .get()
+                .build()
+        val response = okHttpClient.newCall(request).execute()
+        val hasCalendarHeaders = response.header(CONTENT_TYPE) == I_CALENDAR_UTF_8.toString()
+        if (!hasCalendarHeaders) {
+            throw InvalidCalendarException(url, "URL did not return iCal media type.")
+        }
     }
 }

--- a/src/main/kotlin/com/merricklabs/aion/resources/CalendarResource.kt
+++ b/src/main/kotlin/com/merricklabs/aion/resources/CalendarResource.kt
@@ -4,9 +4,11 @@ import com.fasterxml.jackson.databind.ObjectMapper
 import com.merricklabs.aion.params.EntityId
 import com.merricklabs.aion.resources.logic.CalendarLogic
 import com.merricklabs.aion.resources.models.CreateCalendarPayload
+import com.merricklabs.aion.resources.models.ValidationMessage
 import com.merricklabs.aion.resources.util.AionHeaders.AION_VND
 import com.merricklabs.aion.resources.util.PathParams.CALENDAR_ID
 import com.merricklabs.aion.resources.util.PathParams.FILTER_ID
+import org.eclipse.jetty.http.HttpStatus
 import org.koin.core.KoinComponent
 import org.koin.core.inject
 import java.net.URI
@@ -37,6 +39,13 @@ class CalendarResource : KoinComponent {
     @Produces(AION_VND)
     fun createCalendar(body: String): Response {
         val createPayload = mapper.readValue(body, CreateCalendarPayload::class.java)
+        validate(createPayload)?.let {
+            return Response
+                    .status(HttpStatus.BAD_REQUEST_400)
+                    .entity(mapper.writeValueAsString(it))
+                    .build()
+        }
+
         val created = logic.createCalendar(createPayload)
         return Response.created(URI(created.id.value))
                 .entity(mapper.writeValueAsString(created))
@@ -51,5 +60,10 @@ class CalendarResource : KoinComponent {
 
         val body = logic.getFilteredCalendar(EntityId(calendarId), EntityId(filterId))
         return Response.ok(body).build()
+    }
+
+    private fun validate(payload: CreateCalendarPayload): ValidationMessage? {
+        // Todo: Implement this
+        return null
     }
 }

--- a/src/main/kotlin/com/merricklabs/aion/resources/CalendarResource.kt
+++ b/src/main/kotlin/com/merricklabs/aion/resources/CalendarResource.kt
@@ -4,11 +4,9 @@ import com.fasterxml.jackson.databind.ObjectMapper
 import com.merricklabs.aion.params.EntityId
 import com.merricklabs.aion.resources.logic.CalendarLogic
 import com.merricklabs.aion.resources.models.CreateCalendarPayload
-import com.merricklabs.aion.resources.models.ValidationMessage
 import com.merricklabs.aion.resources.util.AionHeaders.AION_VND
 import com.merricklabs.aion.resources.util.PathParams.CALENDAR_ID
 import com.merricklabs.aion.resources.util.PathParams.FILTER_ID
-import org.eclipse.jetty.http.HttpStatus
 import org.koin.core.KoinComponent
 import org.koin.core.inject
 import java.net.URI
@@ -39,12 +37,6 @@ class CalendarResource : KoinComponent {
     @Produces(AION_VND)
     fun createCalendar(body: String): Response {
         val createPayload = mapper.readValue(body, CreateCalendarPayload::class.java)
-        validate(createPayload)?.let {
-            return Response
-                    .status(HttpStatus.BAD_REQUEST_400)
-                    .entity(mapper.writeValueAsString(it))
-                    .build()
-        }
 
         val created = logic.createCalendar(createPayload)
         return Response.created(URI(created.id.value))
@@ -60,10 +52,5 @@ class CalendarResource : KoinComponent {
 
         val body = logic.getFilteredCalendar(EntityId(calendarId), EntityId(filterId))
         return Response.ok(body).build()
-    }
-
-    private fun validate(payload: CreateCalendarPayload): ValidationMessage? {
-        // Todo: Implement this
-        return null
     }
 }

--- a/src/main/kotlin/com/merricklabs/aion/resources/logic/CalendarLogic.kt
+++ b/src/main/kotlin/com/merricklabs/aion/resources/logic/CalendarLogic.kt
@@ -24,6 +24,8 @@ class CalendarLogic : KoinComponent {
     private val geocoderClient by inject<GeocoderClient>()
 
     fun createCalendar(createPayload: CreateCalendarPayload): AionCalendar {
+        calendarClient.validateCalendar(createPayload.url)
+
         val toCreate = createPayload.toDomain()
         calendarStorage.saveCalendar(toCreate)
         return calendarStorage.getCalendar(toCreate.id)

--- a/src/main/kotlin/com/merricklabs/aion/resources/models/ValidationMessage.kt
+++ b/src/main/kotlin/com/merricklabs/aion/resources/models/ValidationMessage.kt
@@ -1,0 +1,3 @@
+package com.merricklabs.aion.resources.models
+
+data class ValidationMessage(val fieldName: String, val message: String)

--- a/src/test/kotlin/com/merricklabs/aion/resources/CalendarResourceTest.kt
+++ b/src/test/kotlin/com/merricklabs/aion/resources/CalendarResourceTest.kt
@@ -38,7 +38,7 @@ const val JSON_TYPE = "application/json"
 
 class CalendarResourceTest : AionIntegrationTestBase() {
 
-    private val okHttpClient by inject<OkHttpClient>()
+    private val okHttpClient = OkHttpClient()
     private val mapper by inject<ObjectMapper>()
     private val calendarStorage by inject<CalendarStorage>()
     private val filterStorage by inject<FilterStorage>()

--- a/src/test/kotlin/com/merricklabs/aion/resources/FilterResourceTest.kt
+++ b/src/test/kotlin/com/merricklabs/aion/resources/FilterResourceTest.kt
@@ -29,7 +29,7 @@ const val FILTER_ENDPOINT = "filters"
 
 class FilterResourceTest : AionIntegrationTestBase() {
 
-    private val okHttpClient by inject<OkHttpClient>()
+    private val okHttpClient = OkHttpClient()
     private val mapper by inject<ObjectMapper>()
     private val filterStorage by inject<FilterStorage>()
 


### PR DESCRIPTION
Now, calendars with unparseable urls or urls with non-calendar headers will fail to be created.